### PR TITLE
Removed "DPS", Added Group/Raid Status

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -31,7 +31,7 @@ if not success_zep then
 end
 
 -- Global UI State
-local combinedUIOpen        = { value = true }-- Use a table for mutable boolean
+local combinedUIOpen        = { value = true, }    -- Use a table for mutable boolean
 local combinedUIInitialized = false
 local showPeerAAWindow      = peers.show_aa_window -- Link directly to the peers module's flag
 local showSortWindow        = peers.show_sort_editor
@@ -57,22 +57,22 @@ local function DrawPlayerStats()
     -- Layout similar to original
     imgui.TextColored(ImVec4(1, 1, 0.7, 1), string.format("Name: %s (Lvl %d)", name, level)) -- Combine Name/Level
     imgui.SameLine()
-    
-        local buttonSize = 22
-        local spacing = 2
-        local windowWidth = imgui.GetWindowContentRegionWidth()
 
-        imgui.SameLine(windowWidth - (buttonSize * 2 + spacing * 2))
-        if imgui.SmallButton("-##fontScaleDown") then
-            peers.options.font_scale = math.max(0.5, peers.options.font_scale - 0.1)
-        end
-        imgui.SameLine()
-        if imgui.SmallButton("+##fontScaleUp") then
-            peers.options.font_scale = math.min(2.0, peers.options.font_scale + 0.1)
-        end
-        if imgui.IsItemHovered() then
-            imgui.SetTooltip("Adjust Font Scale")
-        end
+    local buttonSize = 22
+    local spacing = 2
+    local windowWidth = imgui.GetWindowContentRegionWidth()
+
+    imgui.SameLine(windowWidth - (buttonSize * 2 + spacing * 2))
+    if imgui.SmallButton("-##fontScaleDown") then
+        peers.options.font_scale = math.max(0.5, peers.options.font_scale - 0.1)
+    end
+    imgui.SameLine()
+    if imgui.SmallButton("+##fontScaleUp") then
+        peers.options.font_scale = math.min(2.0, peers.options.font_scale + 0.1)
+    end
+    if imgui.IsItemHovered() then
+        imgui.SetTooltip("Adjust Font Scale")
+    end
 
     local hpText = string.format("HP: %.0f%%", pct_hp)
     local manaText = (max_mana > 0) and string.format("Mana: %.0f%%", pct_mana) or "Mana: N/A"
@@ -82,7 +82,7 @@ local function DrawPlayerStats()
     imgui.SameLine(75)
     imgui.TextColored(ImVec4(0.6, 0.8, 1, 1), manaText) -- Blue-ish for Mana
     imgui.SameLine(160)
-    imgui.TextColored(ImVec4(1, 0.7, 0.5, 1), endText) -- Orange-ish for Endurance
+    imgui.TextColored(ImVec4(1, 0.7, 0.5, 1), endText)  -- Orange-ish for Endurance
 end
 
 ------------------------------------------------------
@@ -95,7 +95,7 @@ local function CombinedUI()
     end
 
     if not mq.TLO.EverQuest.HWND() then return end
-    
+
     if peers.options.borderless then
         windowFlags = bit32.bor(ImGuiWindowFlags.NoTitleBar)
     else
@@ -104,63 +104,63 @@ local function CombinedUI()
 
     -- Begin main window
     if imgui.Begin("EQ Hub", nil, windowFlags) then
-
         if imgui.BeginPopupContextWindow("##HubContext", ImGuiPopupFlags.MouseButtonRight) then
+            imgui.Text("Switcher Options")
+            imgui.Separator()
 
-        imgui.Text("Switcher Options")
-        imgui.Separator()
+            peers.options.show_name         = imgui.Checkbox("Show Name", peers.options.show_name)
+            peers.options.show_hp           = imgui.Checkbox("Show HP (%)", peers.options.show_hp)
+            peers.options.show_endurance    = imgui.Checkbox("Show End (%)", peers.options.show_endurance)
+            peers.options.show_mana         = imgui.Checkbox("Show Mana (%)", peers.options.show_mana)
+            peers.options.show_pethp        = imgui.Checkbox("Show PetHP (%)", peers.options.show_pethp)
+            peers.options.show_distance     = imgui.Checkbox("Show Distance", peers.options.show_distance)
+            peers.options.show_target       = imgui.Checkbox("Show Target", peers.options.show_target)
+            peers.options.show_combat       = imgui.Checkbox("Show Combat", peers.options.show_combat)
+            peers.options.show_casting      = imgui.Checkbox("Show Casting", peers.options.show_casting)
+            peers.options.show_group        = imgui.Checkbox("Show Group Status", peers.options.show_group)
+            peers.options.borderless        = imgui.Checkbox("Borderless", peers.options.borderless)
+            peers.options.show_player_stats = imgui.Checkbox("Show Player Stats", peers.options.show_player_stats)
+            peers.options.use_class         = imgui.Checkbox("Use Class Name", peers.options.use_class)
+            imgui.Separator()
 
-        peers.options.show_name     = imgui.Checkbox("Show Name", peers.options.show_name)
-        peers.options.show_hp       = imgui.Checkbox("Show HP (%)", peers.options.show_hp)
-        peers.options.show_mana     = imgui.Checkbox("Show Mana (%)", peers.options.show_mana)
-        peers.options.show_distance = imgui.Checkbox("Show Distance", peers.options.show_distance)
-        peers.options.show_dps      = imgui.Checkbox("Show DPS", peers.options.show_dps)
-        peers.options.show_target   = imgui.Checkbox("Show Target", peers.options.show_target)
-        peers.options.show_combat   = imgui.Checkbox("Show Combat", peers.options.show_combat)
-        peers.options.show_casting  = imgui.Checkbox("Show Casting", peers.options.show_casting)
-        peers.options.borderless    = imgui.Checkbox("Borderless", peers.options.borderless)
-        peers.options.show_player_stats = imgui.Checkbox("Show Player Stats", peers.options.show_player_stats)
-        peers.options.use_class     = imgui.Checkbox("Use Class Name", peers.options.use_class)
-        imgui.Separator()
-
-        -- Sort submenu
-        if imgui.BeginMenu("Sort By") then
-            if imgui.MenuItem("Alphabetical", nil, peers.options.sort_mode == "Alphabetical") then
-            peers.options.sort_mode = "Alphabetical"
+            -- Sort submenu
+            if imgui.BeginMenu("Sort By") then
+                if imgui.MenuItem("Alphabetical", nil, peers.options.sort_mode == "Alphabetical") then
+                    peers.options.sort_mode = "Alphabetical"
+                end
+                if imgui.MenuItem("HP (Asc)", nil, peers.options.sort_mode == "HP") then
+                    peers.options.sort_mode = "HP"
+                end
+                if imgui.MenuItem("Distance (Asc)", nil, peers.options.sort_mode == "Distance") then
+                    peers.options.sort_mode = "Distance"
+                end
+                if imgui.MenuItem("Class", nil, peers.options.sort_mode == "Class") then
+                    peers.options.sort_mode = "Class"
+                end
+                if imgui.MenuItem("Group", nil, peers.options.sort_mode == "Group") then
+                    peers.options.sort_mode = "Group"
+                end
+                if imgui.MenuItem("Custom", nil, peers.options.sort_mode == "Custom") then
+                    peers.options.sort_mode = "Custom"
+                end
+                imgui.EndMenu()
             end
-            if imgui.MenuItem("HP (Asc)",      nil, peers.options.sort_mode == "HP") then
-            peers.options.sort_mode = "HP"
-            end
-            if imgui.MenuItem("Distance (Asc)",nil, peers.options.sort_mode == "Distance") then
-            peers.options.sort_mode = "Distance"
-            end
-            if imgui.MenuItem("DPS (Desc)",    nil, peers.options.sort_mode == "DPS") then
-            peers.options.sort_mode = "DPS"
-            end
-            if imgui.MenuItem("Class", nil, peers.options.sort_mode == "Class") then
-            peers.options.sort_mode = "Class"
-            end
-            if imgui.MenuItem("Custom", nil, peers.options.sort_mode == "Custom") then
-            peers.options.sort_mode = "Custom"
-            end
-            imgui.EndMenu()
-        end
 
-        imgui.Separator()
-        if imgui.MenuItem("Show Sort Window") then
-            showSortWindow.value = not showSortWindow.value
-        end
+            imgui.Separator()
+            if imgui.MenuItem("Show Sort Window") then
+                showSortWindow.value = not showSortWindow.value
+            end
 
-        imgui.Separator()
-        if imgui.MenuItem("Show AA Window", nil, showPeerAAWindow.value) then
-            showPeerAAWindow.value = not showPeerAAWindow.value
-        end
+            imgui.Separator()
+            if imgui.MenuItem("Show AA Window", nil, showPeerAAWindow.value) then
+                showPeerAAWindow.value = not showPeerAAWindow.value
+            end
 
-        if imgui.MenuItem("Save Config Now") then
-            peers.save_config()
-        end
+            if imgui.MenuItem("Save Config Now") then
+                peers.save_config()
+            end
 
-        imgui.EndPopup()
+            imgui.EndPopup()
         end
 
         -- == Player Stats Section ==
@@ -171,7 +171,7 @@ local function CombinedUI()
         end
 
         -- == Switcher Section ==
-        local peerData = peers.get_peer_data() -- Get current peer data
+        local peerData = peers.get_peer_data()                    -- Get current peer data
         imgui.TextColored(ImVec4(0.7, 0.9, 1, 1), string.format("Peer Switcher (%d)", peerData.count))
         imgui.SameLine(imgui.GetWindowContentRegionWidth() - 100) -- Align AA to the right
         imgui.TextColored(ImVec4(0.8, 0.8, 1, 1), string.format("My AA: %d", peerData.my_aa))
@@ -187,7 +187,7 @@ local function CombinedUI()
             ImGui.SetWindowFontScale(peers.options.font_scale)
             peers.draw_peer_list()
         end
-        imgui.EndChild()          
+        imgui.EndChild()
     end
     imgui.End() -- End main window
 


### PR DESCRIPTION
*Removed DPS tracking.

* Added a sortable "Group" Field:
* * This field will display a red "X" for any peer not in your group/raid.
* * If in your group, the F hotkey for that member will be shown (ex: F2 for your second party member, F1 for self).
* * If in your raid, the group number will be shown as "G#" (ex: G2 if in raid group 2, G0 if in raid but not assigned to a group).

* Minor refactors on a couple of functions (made these before i intended to PR and before I decided I wasn't going to go mucking around too much).

Please pardon the minor changes made with my autoformatting. I would need to remember how to turn it off XD

<img width="126" height="184" alt="image" src="https://github.com/user-attachments/assets/db3a1e74-2f76-4e66-8e06-82fe4c1ed3a5" />
